### PR TITLE
fix spacing and alignment on Consents from household members screen

### DIFF
--- a/caregiver-portal/src/components/HouseholdSummary.jsx
+++ b/caregiver-portal/src/components/HouseholdSummary.jsx
@@ -21,7 +21,7 @@ const HouseholdSummary = ({applicationPackageId}) => {
 
     return (
         <div className="page-details-content-col">
-        <h1 className="page-title">Consents from household members</h1>
+        <h1>Consents from household members</h1>
         <div className="section-description">
         In order to process your application, each adult you listed as residing in your household will need to submit to a screening process.
         </div>

--- a/caregiver-portal/src/components/HouseholdSummaryItem.jsx
+++ b/caregiver-portal/src/components/HouseholdSummaryItem.jsx
@@ -17,15 +17,15 @@ const HouseholdSummaryItem = ({member, onClick}) => {
                     }
 
                     { member.screeningInfoProvided && (
-                    <div className="caption">Tasks completed</div>
+                    <div>Tasks completed</div>
                     )}
 
                     { !member.screeningInfoProvided && member.requireScreening && (
-                    <div className="caption">Tasks still outstanding</div>
+                    <div>Tasks still outstanding</div>
                     )}
 
                     { !member.requireScreening && (
-                    <div className="caption">Screening information is not required for non-adult household members.</div>
+                    <div>Screening information is not required for non-adult household members.</div>
                     )}
                 </div>
             </div>


### PR DESCRIPTION
These changes to address [Defect 9784](https://dev.azure.com/bc-icm/Caregiver%20Registry/_workitems/edit/9784/).

_Removing_ the classes on this page (rather than _adjusting the styles_ of those classes) seems to be the quickest way to fix spacing here but not mess it up in other places — `.caption` and `.page-title` are used in a number of different contexts.