### PR TITLE
fix(pipelines): pass NAMESPACE to helm-deploy from branch mapping

### DIFF
--- a/pipelines/pipeline.yaml
+++ b/pipelines/pipeline.yaml
@@ -163,6 +163,8 @@ spec:
           value: $(params.imageUrl)
         - name: IMAGE_TAG
           value: $(params.branchName)
+        - name: NAMESPACE
+          value: $(tasks.set-vite-secret.results.namespace)
       taskRef:
         kind: Task
         name: helm-deploy


### PR DESCRIPTION
## Problem

`set-vite-secret` already resolves `branchName` to a target namespace (`main` → `f6e00d-prod`), but its `namespace` result was only consumed by `buildah` and `reroll-deployment`.

`helm-deploy` received no namespace at all and derived its own by concatenating `f6e00d-` with the image tag, producing `f6e00d-main` on main-branch builds:

```
Error: query: failed to query with labels: secrets is forbidden: User
"system:serviceaccount:f6e00d-tools:pipeline" cannot list resource "secrets"
in API group "" in the namespace "f6e00d-main"
```

The mapping task was correct the whole time — `helm-deploy` simply wasn't wired to it, so the namespace looked right everywhere except where it mattered.

## Change

```yaml
- name: NAMESPACE
  value: $(tasks.set-vite-secret.results.namespace)
```

Ordering is already safe: `helm-deploy` runs after `buildah`, which runs after `set-vite-secret`, so the result is resolved by the time it's read.

Pairs with the `NAMESPACE` param added to the shared `helm-deploy` task in `bcgov/social-middleware`.

## Verification

Prod deployed successfully after this change: `portal` release revision 12, `Upgrade complete`, image `portal:main` into `f6e00d-prod`, 2/2 pods healthy. The prior successful prod deploy was revision 11 in March.

🤖 Generated with [Claude Code](https://claude.com/claude-code)