### PR TITLE
fix(pipelines): sync portal chart with the cluster (trivy registry + trigger filter)

### DIFF
--- a/pipelines/pipelines-portal-helm/templates/buildahvite.yaml
+++ b/pipelines/pipelines-portal-helm/templates/buildahvite.yaml
@@ -123,7 +123,7 @@ spec:
           mountPath: /var/lib/containers
 
     - name: trivy-scan
-      image: docker.io/aquasec/trivy:0.69.3
+      image: ghcr.io/aquasecurity/trivy:0.69.3
       script: |
         trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.BRANCH_NAME)
       workingDir: $(workspaces.source.path)

--- a/pipelines/pipelines-portal-helm/templates/trigger.yaml
+++ b/pipelines/pipelines-portal-helm/templates/trigger.yaml
@@ -13,19 +13,14 @@ spec:
             - key: branchName
               # Extract branch name from refs/heads/<branch>
               expression: "body.ref.split('/')[2]"
+        # Matches the filter running in f6e00d-tools. The webhook sends both
+        # push and pull_request, so each event type is guarded explicitly:
+        # push payloads carry body.ref, pull_request payloads do not.
         - name: filter
-          value: |
-            (
-              body.ref.split('/')[2] in ['main', 'prod', 'dev', 'develop', 'test']
-            )
-            &&
-            (
-              body.head_commit.modified.exists(file,
-                file.startsWith('caregiver-portal')
-                || file.startsWith('portal-helm')
-                || file.startsWith('pipelines')
-              )
-            )
+          value: >-
+            (header.match("X-GitHub-Event", "push") && body.ref.split("/")[2] in ["main", "prod", "dev", "develop", "test"])
+            ||
+            (header.match("X-GitHub-Event", "pull_request") && body.pull_request.head.ref in ["main", "prod", "dev", "develop", "test"] && body.action in ["opened", "synchronize", "reopened"])
     - ref:
         name: github
         kind: ClusterInterceptor


### PR DESCRIPTION
Companion to bcgov/social-middleware#272, which fixed a Docker Hub rate limit that was breaking builds.

Two changes, both bringing this chart in line with what is deployed in `f6e00d-tools`, so that `helm upgrade portal-p` becomes safe to run.

## 1. trivy pulls from GHCR

```diff
-  image: docker.io/aquasec/trivy:0.69.3
+  image: ghcr.io/aquasecurity/trivy:0.69.3
```

Same scanner version — only the registry changes, to the upstream Aquasecurity org on GHCR, which is not subject to Docker Hub's unauthenticated pull limit.

This image is already pinned, so its implied `imagePullPolicy` is `IfNotPresent` and it was **not** part of the live break. The portal pipeline shares four of its six tasks with social-middleware (`git-clone`, `generate-id`, `helm-deploy`, `reroll-deployment`), and every image responsible for the rate limit lived in those; they were fixed and deployed as `tasks` revision 13. This is a consistency change to match the shared `buildah` task.

## 2. Trigger filter synced to the cluster

The chart's CEL filter had drifted from the deployed `Trigger`, so a `helm upgrade` would have silently changed webhook behaviour.

**Chart, before:**

```
( body.ref.split('/')[2] in ['main', 'prod', 'dev', 'develop', 'test'] )
&&
( body.head_commit.modified.exists(file,
    file.startsWith('caregiver-portal') || file.startsWith('portal-helm') || file.startsWith('pipelines')) )
```

Branch check plus a path filter, with no event-type guard. The GitHub webhook is configured to send **both** event types:

```
id=552673785  active=true  events=pull_request,push
```

`pull_request` payloads carry neither `body.head_commit` nor `body.ref`, so that expression **errors** rather than cleanly not-matching when a PR event arrives, and PR-triggered builds stop working.

**Now:** the filter actually running in the cluster, which guards each event type explicitly and handles pushes and pull requests separately.

The path filter is dropped — it does not exist in the cluster, and keeping current behaviour was the deliberate call. Worth revisiting on its own if the build volume is a problem, but it needs the event-type guards to be safe.

## Verification

Chart rendered and compared against every live object:

```
MATCH    EventListener/portal-build-push-image-trigger
MATCH    TriggerBinding/portal-github-trigger-binding
MATCH    TriggerTemplate/portal-github-trigger
Trigger/portal-github-trigger    filter strings byte-identical
Task/buildah-vite                only the intended trivy change
```

Remaining differences are Tekton's defaulting (`kind: TriggerBinding`, `kind: ClusterInterceptor`).

## After merge

`helm upgrade portal-p -n f6e00d-tools` is then safe — it ships the trivy registry change and leaves webhook behaviour exactly as it is today. Not deployed as part of this PR.

## Note

An earlier revision of this description claimed `dev` had regressed and lost the `helm-deploy` NAMESPACE change from #177. That was wrong — a stale local fetch on my side. `dev` has it via merge commit `b743418`. This branch is rebased on current `dev`.

Still true: `test` is behind `main` and its `pipeline.yaml` has no `NAMESPACE`. The shared `helm-deploy` task declares that param with no default, so a Pipeline applied from `test` would fail Tekton validation. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)