### PR TITLE
promote(pipelines): dev -> test

### DIFF
--- a/pipelines/pipeline.yaml
+++ b/pipelines/pipeline.yaml
@@ -163,6 +163,8 @@ spec:
           value: $(params.imageUrl)
         - name: IMAGE_TAG
           value: $(params.branchName)
+        - name: NAMESPACE
+          value: $(tasks.set-vite-secret.results.namespace)
       taskRef:
         kind: Task
         name: helm-deploy

--- a/pipelines/pipelines-portal-helm/templates/buildahvite.yaml
+++ b/pipelines/pipelines-portal-helm/templates/buildahvite.yaml
@@ -123,7 +123,7 @@ spec:
           mountPath: /var/lib/containers
 
     - name: trivy-scan
-      image: docker.io/aquasec/trivy:0.69.3
+      image: ghcr.io/aquasecurity/trivy:0.69.3
       script: |
         trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.BRANCH_NAME)
       workingDir: $(workspaces.source.path)

--- a/pipelines/pipelines-portal-helm/templates/trigger.yaml
+++ b/pipelines/pipelines-portal-helm/templates/trigger.yaml
@@ -13,19 +13,14 @@ spec:
             - key: branchName
               # Extract branch name from refs/heads/<branch>
               expression: "body.ref.split('/')[2]"
+        # Matches the filter running in f6e00d-tools. The webhook sends both
+        # push and pull_request, so each event type is guarded explicitly:
+        # push payloads carry body.ref, pull_request payloads do not.
         - name: filter
-          value: |
-            (
-              body.ref.split('/')[2] in ['main', 'prod', 'dev', 'develop', 'test']
-            )
-            &&
-            (
-              body.head_commit.modified.exists(file,
-                file.startsWith('caregiver-portal')
-                || file.startsWith('portal-helm')
-                || file.startsWith('pipelines')
-              )
-            )
+          value: >-
+            (header.match("X-GitHub-Event", "push") && body.ref.split("/")[2] in ["main", "prod", "dev", "develop", "test"])
+            ||
+            (header.match("X-GitHub-Event", "pull_request") && body.pull_request.head.ref in ["main", "prod", "dev", "develop", "test"] && body.action in ["opened", "synchronize", "reopened"])
     - ref:
         name: github
         kind: ClusterInterceptor


### PR DESCRIPTION
Promotion of the portal pipeline changes from `dev` to `test`. #178 is merged and its dev build passed (`pipeline-build-run-np2lz`, succeeded).

## What this carries

`pipelines/` only. No application code.

```
pipelines/pipeline.yaml
pipelines/pipelines-portal-helm/templates/buildahvite.yaml
pipelines/pipelines-portal-helm/templates/trigger.yaml
```

- **#177** — `pipeline.yaml` passes `NAMESPACE` to `helm-deploy` from the branch mapping. `test` does not currently have this, and the shared `helm-deploy` task declares `NAMESPACE` with no default, so a Pipeline applied from `test` today would fail Tekton validation. This promotion fixes that.
- **#178** — trivy pulls from GHCR instead of Docker Hub, and the Trigger CEL filter is synced to the one actually running in `f6e00d-tools`.

## Important: merging this does not deploy the chart changes

The `buildahvite.yaml` and `trigger.yaml` changes live in the `pipelines-react-helm` chart, which is applied manually with `helm upgrade portal-p`, not by the pipeline. Likewise `pipeline.yaml` is a standalone Pipeline resource.

So merging this promotes the **source of truth** in git; it does not by itself change anything in the cluster. The cluster already matches these files — that was the point of #178, which synced the chart to the live Trigger rather than the other way round.

What merging *does* do is push to `test`, which the live webhook matches, triggering a portal build and deploy to `f6e00d-test` using the existing pipeline.

## Verification so far

| Run | Trigger | Result |
|---|---|---|
| `pipeline-build-run-np2lz` | #178 → `dev` | Succeeded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)