### PR TITLE
promote(pipelines): test -> main

### DIFF
--- a/pipelines/pipeline.yaml
+++ b/pipelines/pipeline.yaml
@@ -163,6 +163,8 @@ spec:
           value: $(params.imageUrl)
         - name: IMAGE_TAG
           value: $(params.branchName)
+        - name: NAMESPACE
+          value: $(tasks.set-vite-secret.results.namespace)
       taskRef:
         kind: Task
         name: helm-deploy

--- a/pipelines/pipelines-portal-helm/templates/buildahvite.yaml
+++ b/pipelines/pipelines-portal-helm/templates/buildahvite.yaml
@@ -123,7 +123,7 @@ spec:
           mountPath: /var/lib/containers
 
     - name: trivy-scan
-      image: docker.io/aquasec/trivy:0.69.3
+      image: ghcr.io/aquasecurity/trivy:0.69.3
       script: |
         trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.BRANCH_NAME)
       workingDir: $(workspaces.source.path)

--- a/pipelines/pipelines-portal-helm/templates/trigger.yaml
+++ b/pipelines/pipelines-portal-helm/templates/trigger.yaml
@@ -13,19 +13,14 @@ spec:
             - key: branchName
               # Extract branch name from refs/heads/<branch>
               expression: "body.ref.split('/')[2]"
+        # Matches the filter running in f6e00d-tools. The webhook sends both
+        # push and pull_request, so each event type is guarded explicitly:
+        # push payloads carry body.ref, pull_request payloads do not.
         - name: filter
-          value: |
-            (
-              body.ref.split('/')[2] in ['main', 'prod', 'dev', 'develop', 'test']
-            )
-            &&
-            (
-              body.head_commit.modified.exists(file,
-                file.startsWith('caregiver-portal')
-                || file.startsWith('portal-helm')
-                || file.startsWith('pipelines')
-              )
-            )
+          value: >-
+            (header.match("X-GitHub-Event", "push") && body.ref.split("/")[2] in ["main", "prod", "dev", "develop", "test"])
+            ||
+            (header.match("X-GitHub-Event", "pull_request") && body.pull_request.head.ref in ["main", "prod", "dev", "develop", "test"] && body.action in ["opened", "synchronize", "reopened"])
     - ref:
         name: github
         kind: ClusterInterceptor


### PR DESCRIPTION
Final step of the portal pipeline promotion. `dev` → `test` (#179) is merged and the test build passed (`pipeline-build-run-qxgtol`).

## What this carries

Verified with `git merge-tree` — clean merge, no conflicts, and it changes **exactly two files, both under `pipelines/`**:

```
pipelines/pipelines-portal-helm/templates/buildahvite.yaml   |  2 +-
pipelines/pipelines-portal-helm/templates/trigger.yaml       | 19 +++++-------
```

No application code. `pipeline.yaml` is not in the diff — `main` already has the `NAMESPACE` change from #177 by another path, so only `test` had been missing it, and #179 resolved that.

Contents:

- **trivy pulls from GHCR** rather than Docker Hub. Same scanner version (0.69.3), upstream Aquasecurity org, not subject to Docker Hub's unauthenticated pull limit.
- **Trigger CEL filter synced to the cluster.** The chart had drifted: it filtered on branch plus a path filter over `body.head_commit.modified` with no event-type guard, while the webhook sends both `push` and `pull_request`. PR payloads carry neither `body.head_commit` nor `body.ref`, so that expression errored rather than cleanly not-matching, and PR-triggered builds would have stopped. The filter now renders byte-identical to the live Trigger.

## Deployment effect

Merging pushes to `main`, which the live webhook matches, so it builds and deploys to production.

Note that this promotion does **not** by itself apply the chart changes — `buildahvite.yaml` and `trigger.yaml` belong to `pipelines-react-helm`, which is applied manually via `helm upgrade portal-p`. Merging syncs git; the cluster already matches these files, which was the point of #178. Applying the chart is a separate, now-safe step.

## Related: Docker Hub rate limit

The `test` run initially failed at `helm-deploy`:

```
Failed to pull image "docker.io/lachlanevenson/k8s-helm:v3.7.0":
toomanyrequests: You have reached your unauthenticated pull rate limit
```

The image is pinned, so it only pulls on a node cache miss — but with 15 nodes and arbitrary scheduling, that is routine rather than rare. A Docker Hub pull secret has since been added to the `pipeline` service account in `f6e00d-tools` and verified with a forced `imagePullPolicy: Always` pull of that exact image. The rerun passed.

Still outstanding: `lachlanevenson/k8s-helm` is unmaintained (v3.7.0 here, v3.10.2 in social-middleware) and there is no public helm CLI image on GHCR or Quay to move to. Mirroring a current helm into the internal registry would retire it. Not addressed here.

## Track record

| Run | Trigger | Result |
|---|---|---|
| `pipeline-build-run-np2lz` | #178 → `dev` | Succeeded |
| `pipeline-build-run-zmmsc` | #179 → `test` | Failed (Docker Hub rate limit) |
| `pipeline-build-run-qxgtol` | rerun after pull secret | Succeeded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)